### PR TITLE
Changed from DIGEST to BASIC

### DIFF
--- a/src/Switchvox/SwitchvoxClient.php
+++ b/src/Switchvox/SwitchvoxClient.php
@@ -23,7 +23,7 @@ class SwitchvoxClient
 	{
 		$request = Request::post($this->uri . '/' . $this->data_type)
 
-			->authenticateWithDigest($this->user, $this->password)
+			->authenticateWithBasic($this->user, $this->password)
 
 			->timeout($this->timeout);
 


### PR DESCRIPTION
Switchvox 6.6.0.1 no longer allows DIGEST for API calls, need to use BASIC calls.